### PR TITLE
Add php path and version

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -17,22 +17,27 @@ func StartServer(phpInstaller php.Installer, phpServer php.Server, ioCom php.IOC
 	var phpExe string
 
 	phpExe, err = fs.WhereIsPHP(installDir)
+
+	if err == nil {
+
+		ioCom.Stdout <- "PHP found in " + phpExe
+
+	} else {
+
+	ioCom.Stdin <- "Would you like to install PHP?"
+	result := <-ioCom.Stdin
+
+	if result == "No" {
+		ioCom.Done <- true
+	}
+
+	phpExe, err = phpInstaller.Install(ioCom)
 	if err != nil {
+		ioCom.Stdout <- "Unable to install PHP\n"
+		ioCom.Done <- true
+	}
 
-		ioCom.Stdin <- "Would you like to install PHP?"
-		result := <-ioCom.Stdin
-
-		if result == "No" {
-			ioCom.Done <- true
-		}
-
-		phpExe, err = phpInstaller.Install(ioCom)
-		if err != nil {
-			ioCom.Stdout <- "Unable to install PHP\n"
-			ioCom.Done <- true
-		}
-
-		ioCom.Stdout <- "PHP Installed succefully\n\n"
+	ioCom.Stdout <- "PHP Installed succefully"
 
 	}
 
@@ -40,6 +45,7 @@ func StartServer(phpInstaller php.Installer, phpServer php.Server, ioCom php.IOC
 
 	localDocRoot, _ := filepath.Abs(arguments.DocRoot)
 
+	ioCom.Stdout <- "\n\n"
 	ioCom.Stdout <- "Information\n"
 	ioCom.Stdout <- "-----------\n"
 	ioCom.Stdout <- "Copy your files to: " + localDocRoot + "\n"

--- a/engine/fs/fs.go
+++ b/engine/fs/fs.go
@@ -48,9 +48,9 @@ func createDefaultIndex(basePath string) {
 	<div class="container">
 	<h1>Welcome to your personal web server</h1>
 		<p>
-		<?= "This file is located in: ` + absDoctRoot + string(os.PathSeparator) + `index.php"; ?>
+		<?= 'This file is located in: ` + absDoctRoot + string(os.PathSeparator) + `index.php'; ?>
 		</p>
-		<?= "Replaced it with your own file"; ?>
+		<?= "Replace it with your own file"; ?>
 		<p>
 		<hr>
 		<p>

--- a/engine/php/phpInstaller.go
+++ b/engine/php/phpInstaller.go
@@ -46,7 +46,7 @@ func (i PhpInstaller) Install(ioCom IOCom) (string, error) {
 		return "", err
 	}
 
-	ioCom.Stdout <- "Installing PHP v7.0.0 in your local directory: " + localinstallDir + "\n"
+	ioCom.Stdout <- "Installing PHP v" + version + " in your local directory: " + localinstallDir + "\n"
 
 	err = i.unzip()
 	if err != nil {
@@ -91,10 +91,5 @@ Loop:
 }
 
 func (i PhpInstaller) unzip() error {
-	err := archiver.Unarchive(i.installDir+string(os.PathSeparator)+i.filename, i.installDir)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return archiver.Unarchive(i.installDir+string(os.PathSeparator)+i.filename, i.installDir)
 }


### PR DESCRIPTION
- If PHP is already installed, a message will indicate where it is located
- `phpInstaller` will show the PHP version from the corresponding variable
- Removed unncessary condition in `unzip` method