### PR TITLE
Upgrade to php 7.4.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ EzPHP gives you a personal PHP webserver for development.
 
 The goal of the project is to provide a single **.exe** file that will get you a ready to use PHP development environment.
 
-EzPHP will install PHP v. 7.4.13 downloaded from https://windows.php.net/downloads/releases/php-7.4.13-nts-Win32-vc15-x64.zip
+EzPHP will install PHP v. 7.4.14 downloaded from https://windows.php.net/downloads/releases/php-7.4.14-nts-Win32-vc15-x64.zip
 
 ### Installation
 

--- a/internal/php/installer.go
+++ b/internal/php/installer.go
@@ -31,7 +31,7 @@ func FastInstall(source, installFolder string) (string, error) {
 
 	var confirmation string
 
-	fmt.Print("Would you like to install PHP version 7.4.13? [y/N] ")
+	fmt.Print("Would you like to install PHP version 7.4.14? [y/N] ")
 	fmt.Scanln(&confirmation)
 
 	confirmation = strings.TrimSpace(confirmation)

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 
 const (
 	ezPHPWebsite  = "https://github.com/marcomilon/ezphp"
-	downloadURL   = "https://windows.php.net/downloads/releases/php-7.4.13-nts-Win32-vc15-x64.zip"
-	installFolder = "php-7.4.13"
+	downloadURL   = "https://windows.php.net/downloads/releases/php-7.4.14-nts-Win32-vc15-x64.zip"
+	installFolder = "php-7.4.14"
 )
 
 func main() {


### PR DESCRIPTION
Updating the PHP Install to 7.4.14, rather than 7.4.13, whose URL is invalid now and gives 404 error (probably due to 7.4.14's release two weeks ago).